### PR TITLE
Fix web asset loading path

### DIFF
--- a/Searge_LLM_Node.py
+++ b/Searge_LLM_Node.py
@@ -5,7 +5,7 @@ import folder_paths
 
 GLOBAL_MODELS_DIR = os.path.join(folder_paths.models_dir, "llm_gguf")
 
-WEB_DIRECTORY = "./web/assets/js"
+WEB_DIRECTORY = "./web"
 
 DEFAULT_INSTRUCTIONS = 'Generate a prompt from "{prompt}"'
 

--- a/web/assets/js/output.js
+++ b/web/assets/js/output.js
@@ -1,4 +1,4 @@
-import {app} from "../../scripts/app.js";
+import {app} from "../../../../scripts/app.js";
 import {createTextWidget} from "./utils.js"
 
 app.registerExtension({

--- a/web/assets/js/utils.js
+++ b/web/assets/js/utils.js
@@ -1,4 +1,4 @@
-import {ComfyWidgets} from "../../scripts/widgets.js";
+import {ComfyWidgets} from "../../../../scripts/widgets.js";
 
 export function createTextWidget(app, node, widgetName, styles = {}) {
     const widget = ComfyWidgets["STRING"](node, widgetName, ["STRING", {multiline: true}], app).widget;


### PR DESCRIPTION
## Summary
- expose `web` directory correctly for ComfyUI
- fix relative imports in JS assets

## Testing
- `python -m py_compile Searge_LLM_Node.py`
- `pytest -q`
